### PR TITLE
llvm: Scripting API for fuzzing

### DIFF
--- a/czz-jvm/src/Czz/JVM.hs
+++ b/czz-jvm/src/Czz/JVM.hs
@@ -116,7 +116,7 @@ main = do
     CConf.CmdFuzz fuzzConf -> do
       withFuzzer jvmConf (CConf.pathLen fuzzConf) $ \fuzzer -> do
         doFuzz baseConf fuzzConf fuzzer
-    CConf.CmdScript scriptConf -> Script.run baseConf scriptConf
+    CConf.CmdScript scriptConf -> Script.run baseConf scriptConf return
   return Exit.ExitSuccess
 
   where

--- a/czz-llvm-tui/src/Czz/LLVM/TUI.hs
+++ b/czz-llvm-tui/src/Czz/LLVM/TUI.hs
@@ -48,7 +48,7 @@ import qualified Czz.State as State
 import qualified Czz.State.Stats as Stats
 import qualified Czz.Stop as Stop
 
-import qualified Czz.LLVM as CL
+import qualified Czz.LLVM.Fuzz as CL
 import           Czz.LLVM.Feedback (Feedback)
 import qualified Czz.LLVM.Init as Init
 import qualified Czz.LLVM.Translate as Trans

--- a/czz-llvm/czz-llvm.cabal
+++ b/czz-llvm/czz-llvm.cabal
@@ -63,7 +63,6 @@ library
   hs-source-dirs: src
 
   exposed-modules:
-    Czz.LLVM
     Czz.LLVM.Config.CLI
     Czz.LLVM.CString
     Czz.LLVM.Compile
@@ -72,7 +71,9 @@ library
     Czz.LLVM.Env.Args
     Czz.LLVM.Env.FileSystem
     Czz.LLVM.Feedback
+    Czz.LLVM.Fuzz
     Czz.LLVM.Init
+    Czz.LLVM.Main
     Czz.LLVM.Mutate
     Czz.LLVM.Overrides
     Czz.LLVM.Overrides.Env
@@ -89,6 +90,7 @@ library
     Czz.LLVM.Overrides.Time
     Czz.LLVM.Overrides.Util
     Czz.LLVM.QQ
+    Czz.LLVM.Script
     Czz.LLVM.Translate
     Czz.LLVM.Unimplemented
     Paths_czz_llvm
@@ -111,6 +113,8 @@ library
     directory,
     filepath >= 1.0,
     hashable,
+    husk-cust-func,
+    husk-scheme,
     lens,
     llvm-pretty,
     llvm-pretty-bc-parser,

--- a/czz-llvm/exe/Main.hs
+++ b/czz-llvm/exe/Main.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import           System.Exit (exitWith)
 
-import qualified Czz.LLVM as Czz (main)
+import qualified Czz.LLVM.Main as Czz (main)
 
 main :: IO ()
 main = do

--- a/czz-llvm/src/Czz/LLVM/Main.hs
+++ b/czz-llvm/src/Czz/LLVM/Main.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Czz.LLVM.Main (main) where
+
+import qualified System.Exit as Exit
+
+-- crucible-llvm
+import           Lang.Crucible.LLVM.Extension (LLVM)
+
+import qualified Czz.Config.Type as CConf
+import           Czz.Fuzz (Fuzzer)
+import           Czz.KLimited (IsKLimited)
+import qualified Czz.KLimited as KLimit
+import qualified Czz.Fuzz as Fuzz
+import qualified Czz.Log as Log
+import qualified Czz.Script as Script
+import qualified Czz.Stop as Stop
+
+import qualified Czz.LLVM.Config.CLI as CLI
+import           Czz.LLVM.Config.Type (LLVMConfig)
+import qualified Czz.LLVM.Config.Type as Conf
+import           Czz.LLVM.Env (Env)
+import qualified Czz.LLVM.Fuzz as LFuzz
+import           Czz.LLVM.Feedback (Feedback)
+import qualified Czz.LLVM.Init as Init
+import           Czz.LLVM.Overrides (Effect)
+import qualified Czz.LLVM.Script as LScript
+import qualified Czz.LLVM.Translate as Trans
+
+-- | CLI entry point
+main :: IO Exit.ExitCode
+main = do
+  conf <- CLI.cliConfig
+  let commonConf = Conf.common conf
+  let baseConf = CConf.base commonConf
+  let llvmConf = Conf.llvm conf
+  case CConf.command commonConf of
+    CConf.CmdFuzz fuzzConf -> do
+      withFuzzer llvmConf (CConf.pathLen fuzzConf) $ \fuzzer -> do
+        doFuzz baseConf fuzzConf fuzzer
+    CConf.CmdScript scriptConf ->
+      Script.run baseConf scriptConf (LScript.extendEnv "czz-llvm")
+  return Exit.ExitSuccess
+
+  where
+    withFuzzer ::
+      LLVMConfig ->
+      Int ->
+      (forall k. IsKLimited k => Fuzzer LLVM Env Effect k Feedback -> IO a) ->
+      IO a
+    withFuzzer llvmConf kLimit k =
+      KLimit.withSomeKLimit kLimit $ do
+        translation <- Trans.translate llvmConf  -- Allowed to fail/call exit
+        -- TODO(lb): non-void logger
+        let simLog = Log.with Log.void Init.logToTempFile
+        k (LFuzz.llvmFuzzer llvmConf translation simLog)
+
+    doFuzz baseConf fuzzConf fuzzer = do
+      stop <- Stop.new
+      _finalState <- Fuzz.main baseConf fuzzConf stop fuzzer
+      return ()

--- a/czz-llvm/src/Czz/LLVM/Script.hs
+++ b/czz-llvm/src/Czz/LLVM/Script.hs
@@ -1,0 +1,118 @@
+module Czz.LLVM.Script
+  ( extendEnv
+  ) where
+
+import           Control.Monad.Except (ExceptT(..))  -- for auto
+import           Control.Monad.IO.Class (liftIO)
+import qualified System.IO as IO
+
+import           Data.Parameterized.Nonce (Nonce)
+import qualified Data.Parameterized.Nonce as Nonce
+
+import           Lang.Crucible.LLVM.Extension (LLVM)
+
+import qualified Language.Scheme.Types as LST
+
+import           Language.Scheme.CustFunc (CustFunc)
+import qualified Language.Scheme.CustFunc as Cust
+import           Language.Scheme.Opaque (Opaque(..))  -- for auto
+
+import qualified Czz.KLimited as KLimit
+
+import           Czz.Script.API.Fuzz (SFuzzer)
+import qualified Czz.Script.API.Fuzz as APIFuzz
+
+import qualified Czz.LLVM.Fuzz as LFuzz
+import qualified Czz.LLVM.Config.Type as Conf
+import           Czz.LLVM.Env (Env)
+import           Czz.LLVM.Feedback (Feedback)
+import           Czz.LLVM.Overrides (Effect)
+import           Czz.LLVM.Translate (Translation)
+import qualified Czz.LLVM.Translate as Trans
+
+extendEnv ::
+  String ->
+  LST.Env ->
+  IO LST.Env
+extendEnv pfx e = do
+  nllvm <- Nonce.freshNonce Nonce.globalNonceGenerator
+  nenv <- Nonce.freshNonce Nonce.globalNonceGenerator
+  neff <- Nonce.freshNonce Nonce.globalNonceGenerator
+  nfb <- Nonce.freshNonce Nonce.globalNonceGenerator
+  Cust.extendEnv (funcs nllvm nenv neff nfb) pfx e
+  where
+    funcs nllvm nenv neff nfb =
+      [ defaultConfig
+      , translate
+      , fuzzer nllvm nenv neff nfb
+      ]
+
+-- TODO(lb): these could probably be typeclass-programmed in CustFunc..?
+
+-- | Helper, not exported
+_lift :: IO a -> LST.IOThrowsError a
+_lift = liftIO
+{-# INLINE _lift #-}
+
+-- | Helper, not exported
+lift1 :: (a -> IO b) -> a -> LST.IOThrowsError b
+lift1 f a = liftIO (f a)
+{-# INLINE lift1 #-}
+
+-- | Helper, not exported
+_lift2 :: (a -> b -> IO c) -> a -> b -> LST.IOThrowsError c
+_lift2 f a b = liftIO (f a b)
+{-# INLINE _lift2 #-}
+
+-- | Helper, not exported
+lift3 :: (a -> b -> c -> IO d) -> a -> b -> c -> LST.IOThrowsError d
+lift3 f a b c = liftIO (f a b c)
+{-# INLINE lift3 #-}
+
+-- TODO(lb): Expose a lower-level API, i.e., the LLVM AST
+defaultConfig :: CustFunc
+defaultConfig =
+  Cust.CustFunc
+  { Cust.custFuncName = "default-config"
+  , Cust.custFuncImpl = Cust.evalHuskable (Cust.auto conf)
+  }
+  where
+    conf =
+      Conf.LLVMConfig
+      { Conf.prog = "in.bc"
+      , Conf.entryPoint = "main"
+      , Conf.skip = []
+      , Conf.onlyNeeded = False
+      }
+
+-- TODO(lb): Expose a lower-level API, i.e., the LLVM AST
+translate :: CustFunc
+translate =
+  Cust.CustFunc
+  { Cust.custFuncName = "translate"
+  , Cust.custFuncImpl = Cust.evalHuskable (Cust.auto (lift1 Trans.translate))
+  }
+
+fuzzer ::
+  Nonce Nonce.GlobalNonceGenerator LLVM ->
+  Nonce Nonce.GlobalNonceGenerator Env ->
+  Nonce Nonce.GlobalNonceGenerator Effect ->
+  Nonce Nonce.GlobalNonceGenerator Feedback ->
+  CustFunc
+fuzzer nllvm nenv neff nfb =
+  Cust.CustFunc
+  { Cust.custFuncName = "fuzzer"
+  , Cust.custFuncImpl = Cust.evalHuskable (Cust.auto (lift3 impl))
+  }
+  where
+    impl ::
+      Integer ->
+      Conf.LLVMConfig ->
+      Translation ->
+      IO SFuzzer
+    impl k llvmConf trans =
+      -- TODO(lb): can truncate...
+      KLimit.withSomeKLimit (fromIntegral k) $ do
+        let mkHandle = snd <$> IO.openTempFile "/tmp" "czz.temp"
+        let fz = LFuzz.llvmFuzzer llvmConf trans mkHandle
+        return (APIFuzz.SFuzzer nllvm nenv neff nfb fz)

--- a/czz-llvm/test/Test.hs
+++ b/czz-llvm/test/Test.hs
@@ -24,7 +24,7 @@ import qualified Czz.KLimited as KLimit
 import qualified Czz.State as State
 import qualified Czz.Stop as Stop
 
-import qualified Czz.LLVM as Main
+import qualified Czz.LLVM.Fuzz as Fuzz
 import qualified Czz.LLVM.Compile as Compile
 import qualified Czz.LLVM.Config.Type as Conf
 import qualified Czz.LLVM.Init as Init
@@ -79,7 +79,7 @@ tests = do
            maybeFail $
              TastyG.goldenVsFile (Conf.prog cf <> " output") gold out $ do
                KLimit.withSomeKLimit 1 $
-                 Main.fuzz cf (oneExec fuzzConf) stop simLog logger logger >>=
+                 Fuzz.fuzz cf (oneExec fuzzConf) stop simLog logger logger >>=
                    \case
                      Left err -> error (show err)
                      Right _finalState -> return ()
@@ -87,7 +87,7 @@ tests = do
   let simLog = Log.with Log.void Init.logToTempFile
   let assertFinalState cf fcf logger f =
         TastyH.testCase (Conf.prog cf) $ do
-          Main.fuzz cf fcf stop simLog logger logger >>=
+          Fuzz.fuzz cf fcf stop simLog logger logger >>=
             \case
               Left err -> error (show err)
               Right finalState -> f finalState

--- a/czz/src/Czz/Script.hs
+++ b/czz/src/Czz/Script.hs
@@ -44,8 +44,8 @@ globalEnv =
       liftIO (putStrLn ("Hello, " ++ s))
       return (LST.List [])
 
-run :: BaseConfig -> ScriptConfig -> IO ()
-run baseConf scriptConf = do
+run :: BaseConfig -> ScriptConfig -> (LST.Env -> IO LST.Env) -> IO ()
+run baseConf scriptConf extraLibs = do
   let v = Conf.verbosity baseConf
   let cap = 4096 -- TODO(lb): Good default? Configurable?
   lss <- Lock.new Hand.stdStreams
@@ -55,7 +55,8 @@ run baseConf scriptConf = do
         let sym = C.backendGetSym bak
         r5rsEnv <- LSC.r5rsEnv
         let libs =
-              [ API.extendEnv stdoutLogger stderrLogger
+              [ extraLibs
+              , API.extendEnv stdoutLogger stderrLogger
               , LSWord.extendEnv "word"
               , LSBS.extendEnv "bytes"
               , LSWhat4.extendEnv sym "czz"

--- a/czz/src/Czz/Script/API/Config.hs
+++ b/czz/src/Czz/Script/API/Config.hs
@@ -24,8 +24,7 @@ defaultFuzzConfig :: CustFunc
 defaultFuzzConfig =
   Cust.CustFunc
   { Cust.custFuncName = "default-fuzz-config"
-  , Cust.custFuncImpl =
-      Cust.evalHuskable (Cust.auto conf)
+  , Cust.custFuncImpl = Cust.evalHuskable (Cust.auto conf)
   }
   where
     conf =

--- a/doc/llvm/scripting.rst
+++ b/doc/llvm/scripting.rst
@@ -7,4 +7,25 @@ czz-llvm can be scripted using `Scheme`_.
 API Reference
 =============
 
+``czz-llvm-default-config``
+***************************
+
+.. code-block:: haskell
+
+  LLVMConfig
+
+``czz-llvm-fuzzer``
+*******************
+
+.. code-block:: haskell
+
+  Number -> LLVMConfig -> LLVMTranslation -> Fuzzer
+
+``czz-llvm-translate``
+**********************
+
+.. code-block:: haskell
+
+  LLVMConfig -> LLVMTranslation
+
 .. _Scheme: http://justinethier.github.io/husk-scheme/manual/index.html

--- a/husk/husk-cust-func/src/Language/Scheme/CustFunc.hs
+++ b/husk/husk-cust-func/src/Language/Scheme/CustFunc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -259,6 +260,12 @@ opaqueRet5 = coerce
 -- Auto
 
 type family Auto a where
+  Auto (LST.IOThrowsError a) = LST.IOThrowsError (Auto a)
+  -- This won't be able to match with Coercible, so it will raise an error.
+  -- You should use LST.IOThrowsError instead. Catches silly mistakes that would
+  -- end up turning IO computations opaque, instead of running them.
+  Auto (IO a) = ()
+
   Auto LST.LispVal = LST.LispVal
   Auto (Array i a) = Array i a
   Auto Bool = Bool

--- a/husk/husk-what4/husk-what4.cabal
+++ b/husk/husk-what4/husk-what4.cabal
@@ -68,4 +68,5 @@ library
     husk-cust-func,
     husk-scheme,
     parameterized-utils,
+    mtl,
     what4


### PR DESCRIPTION
Fixes #101, though there's of course more to do with respect to documentation, etc.

Test script:
```scheme
(let* ((llvm-config (czz-llvm-default-config))
       (trans (czz-llvm-translate llvm-config)))
  (czz-fuzz (czz-llvm-fuzzer 1 llvm-config trans) (czz-default-fuzz-config)))
```
will fuzz `in.bc` 's `main`.